### PR TITLE
Slim the missing done_testing() error

### DIFF
--- a/lib/Fennec/Runner.pm
+++ b/lib/Fennec/Runner.pm
@@ -230,11 +230,6 @@ sub DESTROY {
 # This usually means you ran a Fennec test file directly with prove or perl,
 # but the file does not call done_testing at the end.
 #
-# This is new behavior as of Fennec 2.000. Old versions used a couple of evil
-# hacks to make it work without calling done_testing. These resulted in things
-# such as broken coverage tests, broken Win32, and other strange and hard to
-# debug behavior.
-#
 # Fennec Tests loaded, but not run:
 $tests
 #


### PR DESCRIPTION
I did this in two commits.  The first removes the swipe at Win32.  That doesn't need to be there.

The second removes the legacy change info.  While it makes sense to want to warn users of the 2.000 change, it's information you only need to know once, yet it takes up the majority and creates a bit of a wall of text.
